### PR TITLE
add images to sellings and reports

### DIFF
--- a/src/app/client-product-component/client-product-component.component.html
+++ b/src/app/client-product-component/client-product-component.component.html
@@ -8,7 +8,6 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  <!-- Mostrar detalles del producto aquí -->
   <ion-item>
     <ion-label>ID del Producto:</ion-label>
     <ion-text>{{ productDetails.id }}</ion-text>

--- a/src/app/client-product-component/client-product-component.component.ts
+++ b/src/app/client-product-component/client-product-component.component.ts
@@ -44,7 +44,9 @@ export class ClientProductComponentComponent {
     const description = this.productDetails.description;
     const quantity = this.quantityToSell;
     const cost = this.productDetails.sellPrice * quantity;
-    const url = `https://samuelucol.000webhostapp.com/PROYECTO5i/ventas/addVenta.php?id_user=${idUser}&id_client=${id_client}&id_product=${id_product}&name_product=${name_product}&description=${description}&quantity=${quantity}&cost=${cost}`;
+    const img = this.productDetails.img
+
+    const url = `https://samuelucol.000webhostapp.com/PROYECTO5i/ventas/addVenta.php?id_user=${idUser}&id_client=${id_client}&id_product=${id_product}&name_product=${name_product}&description=${description}&quantity=${quantity}&cost=${cost}&img=${img}`;
 
     this.http.get(url).subscribe(
       (response: any) => {

--- a/src/app/reportes/reportes.page.html
+++ b/src/app/reportes/reportes.page.html
@@ -14,12 +14,16 @@
       <ion-label>
         <h2>Folio de ticket: {{ ticket.folio }}</h2>
         <p>Id cliente: {{ ticket.id_client }}</p>
-        <p>Nombre del producto: {{ ticket.name_product }}</p>
+        <p>Nombre: {{ ticket.name_product }}</p>
         <p>Descripción: {{ ticket.description }}</p>
         <p>Cantidad: {{ ticket.quantity }}</p>
         <p>Costo: {{ ticket.cost }}MXN</p>
         <p>Fecha de pago: {{ ticket.paymentDate }}</p>
       </ion-label>
+
+      <ion-thumbnail slot="end">
+        <img [src]="ticket.img" alt="Product Image">
+      </ion-thumbnail>
 
     </ion-item>
   </ion-list>

--- a/src/app/reportes/reportes.page.scss
+++ b/src/app/reportes/reportes.page.scss
@@ -1,0 +1,28 @@
+ion-content {
+  ion-list {
+    ion-item {
+      ion-thumbnail {
+        border-radius: 0;
+        width: 150px; /* Ajusta el tamaño de la imagen */
+        height: auto;
+      }
+
+      ion-label {
+        display: flex;
+        flex-direction: column;
+        margin-left: 5px;
+        flex: 1;
+
+        h2 {
+          font-size: 1.2em;
+          margin-bottom: 5px;
+        }
+
+        p {
+          font-size: 0.9em;
+          color: #777;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ahora se insertan las imágenes de los productos seleccionados automáticamente al generar una venta, y por lo tanto, también en el ticket de reportes.